### PR TITLE
Unify wording around US and EU region

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -36,14 +36,14 @@ IP addresses for released locations are subject to change. If a change is needed
 </Callout>
 
 <Callout variant="tip">
-  In the S3 URL paths for this feature, `production` represents US-based accounts and `eu` represents [EU-based accounts](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
+  In the S3 URL paths for this feature, `production` represents accounts hosted in our US region and `eu` represents [accounts in our EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
 </Callout>
 
 <table style={{ width: "300px" }}>
   <thead>
     <tr>
       <th>
-        US accounts
+        Accounts in US region
       </th>
     </tr>
 
@@ -61,7 +61,7 @@ IP addresses for released locations are subject to change. If a change is needed
   <thead>
     <tr>
       <th>
-        EU accounts
+        Accounts in EU region
       </th>
     </tr>
 


### PR DESCRIPTION
The documentation uses "US region" and "EU region" most of the time. "US accounts" and "EU accounts" seems to have been used on this page only, and it might be misleading.
